### PR TITLE
Added license field to package.json

### DIFF
--- a/smartclide-service-creation-theia/package.json
+++ b/smartclide-service-creation-theia/package.json
@@ -23,6 +23,7 @@
     "build": "tsc -b",
     "watch": "tsc -w"
   },
+  "license": "EPL-2.0",
   "theiaExtensions": [
     {
       "frontend": "lib/browser/smartclide-service-creation-theia-frontend-module"


### PR DESCRIPTION
 The absence of this field raises a warning during the building of a Che-Theia image.