### PR TITLE
Frontend communication fix

### DIFF
--- a/smartclide-service-creation-theia/src/browser/smartclide-service-creation-theia-widget.tsx
+++ b/smartclide-service-creation-theia/src/browser/smartclide-service-creation-theia-widget.tsx
@@ -1,10 +1,10 @@
 /*******************************************************************************
  * Copyright (C) 2021-2022 University of Macedonia
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  ******************************************************************************/
 
@@ -15,6 +15,7 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { MessageService } from '@theia/core';
 import { CommandService } from '@theia/core/lib/common/command';
 import { messageTypes, buildMessage } from '@unparallel/smartclide-frontend-comm';
+import { Message } from '@theia/core/lib/browser';
 
 @injectable()
 export class SmartclideServiceCreationTheiaWidget extends ReactWidget {
@@ -73,6 +74,13 @@ export class SmartclideServiceCreationTheiaWidget extends ReactWidget {
 		let message = buildMessage(messageTypes.COMPONENT_HELLO);
 		window.parent.postMessage(message, "*");
     }
+
+	//After Detach Remove Listener
+	protected onAfterDetach(msg: Message): void {
+		console.log("REMOVING EVENT LISTENER AFTER DETACH")
+		window.removeEventListener("message", this.handleTokenInfo);
+		super.onAfterDetach(msg);
+	}
 
     protected render(): React.ReactNode {
         const header = `Provide the GitLab project configuration details.`;

--- a/smartclide-service-creation-theia/src/browser/smartclide-service-creation-theia-widget.tsx
+++ b/smartclide-service-creation-theia/src/browser/smartclide-service-creation-theia-widget.tsx
@@ -77,7 +77,6 @@ export class SmartclideServiceCreationTheiaWidget extends ReactWidget {
 
 	//After Detach Remove Listener
 	protected onAfterDetach(msg: Message): void {
-		console.log("REMOVING EVENT LISTENER AFTER DETACH")
 		window.removeEventListener("message", this.handleTokenInfo);
 		super.onAfterDetach(msg);
 	}


### PR DESCRIPTION
The listener was not being removed when the extension was closed (removed from the sidebar), causing it to create duplicate handlers when reopening it. This commit fixes that behaviour by removing the listener when the extension is closed.